### PR TITLE
chore:  fix typos and network validation

### DIFF
--- a/src/key/types.rs
+++ b/src/key/types.rs
@@ -15,7 +15,7 @@ pub fn tagged_hash(tag: &str, data: &[u8]) -> [u8; 32] {
     hasher.finalize().into()
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Network {
     Mainnet,
     Testnet,

--- a/src/usecase/generate.rs
+++ b/src/usecase/generate.rs
@@ -40,7 +40,7 @@ pub enum GenerateAddressError {
     CreateVault(#[from] vault::CreateVaultError),
     #[error(transparent)]
     LoadSeed(#[from] vault::LoadSeedError),
-    #[error("path:{0} does not exists")]
+    #[error("path:{0} does not exist")]
     FileNotExist(PathBuf),
     #[error(transparent)]
     CreateDirectory(#[from] std::io::Error),


### PR DESCRIPTION
## Summary
- correct typos in error messages
- ensure network consistency across all inputs
- fix grammar in user-facing errors
- test SignError::Length when lengths mismatch

## Testing
- `cargo test --quiet`